### PR TITLE
Remove non-default mod implementation for GMP adapter

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,8 +19,8 @@ tools:
     php_pdepend:
         excluded_dirs: [vendor, doc, tests]
     external_code_coverage:
-        timeout: 900
-        runs: 1
+        timeout: 1800
+        runs: 5
 
 changetracking:
     bug_patterns: ["\bfix(?:es|ed)?\b"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,3 @@ after_script:
 
 matrix:
     fast_finish: true
-    allow_failures:
-        - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ php:
     - 5.6
     - hhvm
 
+env:
+    - MATH_LIB=gmp
+    - MATH_LIB=bcmath
+
 before_script:
     - composer selfupdate
     - composer install --prefer-source --dev

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="tests/bootstrap.php" colors="true"
-	stopOnFailure="true">
-	<php>
-	   <ini name="display_errors" value="On" />
-	   <ini name="error_reporting" value="32767" />
-	</php>
-	<testsuites>
-		<testsuite name="All">
-			<directory suffix="Test.php">./tests/unit</directory>
-		</testsuite>
-	</testsuites>
-	<logging>
-		<log type="coverage-html" target="./tests/output/Coverage/"
-			charset="UTF-8" yui="true" highlight="true" />
-		<log type="junit" target="./tests/output/Results/Results.xml"
-			logIncompleteSkipped="true" />
-	</logging>
-	<filter>
+  stopOnFailure="true">
+  <php>
+    <const name="PHPUNIT_DEBUG" value="false"/>
+    <ini name="display_errors" value="On" />
+    <ini name="error_reporting" value="32767" />
+  </php>
+  <testsuites>
+    <testsuite name="All">
+      <directory suffix="Test.php">./tests/unit</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <log type="coverage-html" target="./tests/output/Coverage/"
+      charset="UTF-8" yui="true" highlight="true" />
+    <log type="junit" target="./tests/output/Results/Results.xml"
+      logIncompleteSkipped="true" />
+  </logging>
+  <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src/</directory>
             <exclude>

--- a/src/Math/DebugDecorator.php
+++ b/src/Math/DebugDecorator.php
@@ -6,10 +6,10 @@ use Mdanter\Ecc\MathAdapterInterface;
 
 /**
  * Debug helper class to trace all calls to math functions along with the provided params and result.
- *
  */
 class DebugDecorator implements MathAdapterInterface
 {
+
     private $adapter;
 
     private $writer;
@@ -17,7 +17,8 @@ class DebugDecorator implements MathAdapterInterface
     public function __construct(MathAdapterInterface $adapter, $callback = null)
     {
         $this->adapter = $adapter;
-        $this->writer = $callback ?: function ($message) {
+        $this->writer = $callback ?  : function ($message)
+        {
             echo $message;
         };
     }
@@ -28,7 +29,7 @@ class DebugDecorator implements MathAdapterInterface
      */
     private function writeln($message)
     {
-        call_user_func($this->writer, $message.PHP_EOL);
+        call_user_func($this->writer, $message . PHP_EOL);
     }
 
     /**
@@ -42,31 +43,34 @@ class DebugDecorator implements MathAdapterInterface
 
     /**
      *
-     * @param  string $func
-     * @param  array  $args
+     * @param string $func
+     * @param array $args
      * @return mixed
      */
     private function call($func, $args)
     {
-        $strArgs = array_map(
-            function ($arg) {
-                return var_export($this->adapter->toString($arg), true);
-            }, $args
-        );
+        $strArgs = array_map(function ($arg)
+        {
+            return var_export($this->adapter->toString($arg), true);
+        }, $args);
 
         if (strpos($func, '::')) {
-            list(, $func) = explode('::', $func);
+            list (, $func) = explode('::', $func);
         }
 
-        $res = call_user_func_array(array($this->adapter, $func), $args);
+        $res = call_user_func_array(array(
+            $this->adapter,
+            $func
+        ), $args);
 
-        $this->writeln($func.'('.implode(', ', $strArgs).') => '.var_export($this->adapter->toString($res), true));
+        $this->writeln($func . '(' . implode(', ', $strArgs) . ') => ' . var_export($this->adapter->toString($res), true));
 
         return $res;
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::cmp()
      */
     public function cmp($first, $other)
@@ -74,11 +78,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::mod()
      */
     public function mod($number, $modulus)
@@ -86,11 +94,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::add()
      */
     public function add($augend, $addend)
@@ -98,11 +110,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::sub()
      */
     public function sub($minuend, $subtrahend)
@@ -110,11 +126,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::mul()
      */
     public function mul($multiplier, $multiplicand)
@@ -122,11 +142,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::div()
      */
     public function div($dividend, $divisor)
@@ -134,11 +158,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::pow()
      */
     public function pow($base, $exponent)
@@ -146,11 +174,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::rand()
      */
     public function rand($n)
@@ -158,11 +190,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::bitwiseAnd()
      */
     public function bitwiseAnd($first, $other)
@@ -170,11 +206,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::toString()
      */
     public function toString($value)
@@ -184,6 +224,7 @@ class DebugDecorator implements MathAdapterInterface
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::hexDec()
      */
     public function hexDec($hexString)
@@ -191,11 +232,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::decHex()
      */
     public function decHex($decString)
@@ -203,11 +248,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::powmod()
      */
     public function powmod($base, $exponent, $modulus)
@@ -215,11 +264,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::isPrime()
      */
     public function isPrime($n)
@@ -227,11 +280,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::nextPrime()
      */
     public function nextPrime($currentPrime)
@@ -239,11 +296,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::inverseMod()
      */
     public function inverseMod($a, $m)
@@ -251,11 +312,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::jacobi()
      */
     public function jacobi($a, $p)
@@ -263,11 +328,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::intToString()
      */
     public function intToString($x)
@@ -275,11 +344,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::stringToInt()
      */
     public function stringToInt($s)
@@ -287,11 +360,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::digestInteger()
      */
     public function digestInteger($m)
@@ -299,11 +376,15 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 
     /**
      * (non-PHPdoc)
+     *
      * @see \Mdanter\Ecc\MathAdapterInterface::gcd2()
      */
     public function gcd2($a, $m)
@@ -311,6 +392,36 @@ class DebugDecorator implements MathAdapterInterface
         $func = __METHOD__;
         $args = func_get_args();
 
-        return call_user_func(array($this, 'call'), $func, $args);
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
+    }
+    /*
+     * (non-PHPdoc) @see \Mdanter\Ecc\MathAdapterInterface::rightShift()
+     */
+    public function rightShift($number, $positions)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
+    }
+
+    /*
+     * (non-PHPdoc) @see \Mdanter\Ecc\MathAdapterInterface::leftShift()
+     */
+    public function leftShift($number, $positions)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(array(
+            $this,
+            'call'
+        ), $func, $args);
     }
 }

--- a/src/Math/Gmp.php
+++ b/src/Math/Gmp.php
@@ -21,13 +21,7 @@ class Gmp implements MathAdapterInterface
      */
     public function mod($number, $modulus)
     {
-        $res = gmp_div_r($number, $modulus);
-
-        if (gmp_cmp(0, $res) > 0) {
-            $res = gmp_add($modulus, $res);
-        }
-
-        return gmp_strval($res);
+        return gmp_strval(gmp_mod($number, $modulus));
     }
 
     /**
@@ -93,7 +87,7 @@ class Gmp implements MathAdapterInterface
         // Shift 1 right = div / 2
         return gmp_strval(gmp_div($number, gmp_pow(2, $positions)));
     }
-    
+
     /**
      * (non-PHPdoc)
      * @see \Mdanter\Ecc\MathAdapter::rightShift()
@@ -103,7 +97,7 @@ class Gmp implements MathAdapterInterface
         // Shift 1 right = mul * 2
         return gmp_strval(gmp_mul($number, gmp_pow(2, $positions)));
     }
-    
+
     /**
      * (non-PHPdoc)
      * @see \Mdanter\Ecc\MathAdapterInterface::toString()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,4 +7,12 @@ function buildPath()
 
 define('TEST_DATA_DIR', buildPath(__DIR__, 'data'));
 
+if (getenv('MATH_LIB') === false) {
+    echo 'MATH_LIB env var is not defined, defaulting to GMP' . PHP_EOL;
+    define('MATH_LIB', 'gmp');
+}
+else {
+    define('MATH_LIB', getenv('MATH_LIB'));
+}
+
 include buildPath(__DIR__, '..', 'vendor', 'autoload.php');

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -15,10 +15,18 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
             define('PHPUNIT_DEBUG', false);
         }
 
+        switch (MATH_LIB) {
+            case 'bcmath':
+                $adapter = MathAdapterFactory::getBcMathAdapter(PHPUNIT_DEBUG);
+                break;
+            case 'gmp':
+            default:
+                $adapter = MathAdapterFactory::getGmpAdapter(PHPUNIT_DEBUG);
+        }
+
         if ($extra == null) {
             return array(
-                array(MathAdapterFactory::getGmpAdapter(PHPUNIT_DEBUG)),
-                array(MathAdapterFactory::getBcMathAdapter(PHPUNIT_DEBUG))
+                array($adapter)
             );
         }
 

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -11,10 +11,14 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 {
     protected function _getAdapters(array $extra = null)
     {
+        if (! defined('PHPUNIT_DEBUG')) {
+            define('PHPUNIT_DEBUG', false);
+        }
+
         if ($extra == null) {
             return array(
-                array(MathAdapterFactory::getGmpAdapter()),
-                array(MathAdapterFactory::getBcMathAdapter())
+                array(MathAdapterFactory::getGmpAdapter(PHPUNIT_DEBUG)),
+                array(MathAdapterFactory::getBcMathAdapter(PHPUNIT_DEBUG))
             );
         }
 


### PR DESCRIPTION
Original GMP adapter used a [custom mod function (see ¤5.1.2)](http://www.matyasdanter.com/2010/12/elliptic-curve-php-oop-dsa-and-diffie-hellman/) to compensate for this [bug](https://bugs.php.net/bug.php?id=52906), which is now fixed.

Also improves the build process by splitting it into smaller tasks (used adapter is defined through an env var in the build matrix), which allows to get quicker feedback on failures.