### PR TITLE
Updated the shebang line to allow proper detection of php binary

### DIFF
--- a/bin/phpecc
+++ b/bin/phpecc
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 (@include_once __DIR__ . '/../vendor/autoload.php') || @include_once __DIR__ . '/../../../autoload.php';


### PR DESCRIPTION
With php installed through home-brew for example on Mac, the OS version of php is located at /usr/bin/php, and the home-brew version is /usr/local/bin/php.