### PR TITLE
Enable DumpAsnCommand

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -19,7 +19,7 @@ class Application extends ConsoleApplication
     {
         $commands = parent::getDefaultCommands();
 
-        //$commands[] = new DumpAsnCommand();
+        $commands[] = new DumpAsnCommand();
         $commands[] = new GenerateKeyPairCommand();
         $commands[] = new GeneratePublicKeyCommand();
         $commands[] = new ListCurvesCommand();

--- a/src/Console/Commands/DumpAsnCommand.php
+++ b/src/Console/Commands/DumpAsnCommand.php
@@ -30,7 +30,8 @@ class DumpAsnCommand extends AbstractCommand
         $this->printObject($output, $asnObject);
     }
 
-    function printObject(OutputInterface $output, Object $object, $depth=0) {
+    function printObject(OutputInterface $output, Object $object, $depth=0)
+    {
         $treeSymbol = '';
         $depthString = str_repeat('─', $depth);
         if($depth > 0) {

--- a/src/Console/Commands/DumpAsnCommand.php
+++ b/src/Console/Commands/DumpAsnCommand.php
@@ -30,7 +30,7 @@ class DumpAsnCommand extends AbstractCommand
         $this->printObject($output, $asnObject);
     }
 
-    function printObject(OutputInterface $output, Object $object, $depth=0)
+    protected function printObject(OutputInterface $output, Object $object, $depth=0)
     {
         $treeSymbol = '';
         $depthString = str_repeat('─', $depth);

--- a/src/Console/Commands/DumpAsnCommand.php
+++ b/src/Console/Commands/DumpAsnCommand.php
@@ -2,6 +2,7 @@
 
 namespace Mdanter\Ecc\Console\Commands;
 
+use FG\ASN1\Identifier;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,7 +27,25 @@ class DumpAsnCommand extends AbstractCommand
         $data = $this->getPrivateKeyData($input, $loader, 'infile', 'data');
 
         $asnObject = Object::fromBinary(base64_decode($data));
+        $this->printObject($output, $asnObject);
+    }
 
-        throw new \RuntimeException('Command not available.');
+    function printObject(OutputInterface $output, Object $object, $depth=0) {
+        $treeSymbol = '';
+        $depthString = str_repeat('─', $depth);
+        if($depth > 0) {
+            $treeSymbol = '├';
+        }
+
+        $name = Identifier::getShortName($object->getType());
+        $output->write("{$treeSymbol}{$depthString}<comment>{$name}</comment> : ");
+        $output->writeln($object->__toString());
+
+        $content = $object->getContent();
+        if(is_array($content)) {
+            foreach ($object as $child) {
+                $this->printObject($output, $child, $depth+1);
+            }
+        }
     }
 }

--- a/src/Console/Commands/DumpAsnCommand.php
+++ b/src/Console/Commands/DumpAsnCommand.php
@@ -30,11 +30,11 @@ class DumpAsnCommand extends AbstractCommand
         $this->printObject($output, $asnObject);
     }
 
-    protected function printObject(OutputInterface $output, Object $object, $depth=0)
+    private function printObject(OutputInterface $output, Object $object, $depth=0)
     {
         $treeSymbol = '';
         $depthString = str_repeat('─', $depth);
-        if($depth > 0) {
+        if ($depth > 0) {
             $treeSymbol = '├';
         }
 
@@ -43,7 +43,7 @@ class DumpAsnCommand extends AbstractCommand
         $output->writeln($object->__toString());
 
         $content = $object->getContent();
-        if(is_array($content)) {
+        if (is_array($content)) {
             foreach ($object as $child) {
                 $this->printObject($output, $child, $depth+1);
             }


### PR DESCRIPTION
This implements the logic for the preexisting DumpAsnCommand. You might want to change the exact format in which the ASN.1 objects are displayed but the general logic will probably stay the same.

You can try the command right from a checked out repo using:

```
$ ./bin/phpecc dump-asn --infile tests/data/openssl-priv.key --in der
Sequence : [4 children]
├─Integer : 1
├─Octet String : D3645A981ACF044D86A29EAA6668B969E3266CE61020A880B5144FF863535300
├─[0] Context-specific (0xa0) : [1 child]
├──Object Identifier : Prime256v1 (1.2.840.10045.3.1.7)
├─[1] Context-specific (0xa1) : [1 child]
├──Bit String : 04E553637CF7D3310081A94D6BC2CCF8C9F7F638502E8B2349B03C316566EB8437911F444C3C4700E0DAAB1EB4A0E9D6AC927775578BD3ED6624523EE6C7B6818A
```