### PR TITLE
Document dependency on bcmath extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
    ],
    "require":{
        "php": ">=5.4.0",
+       "ext-bcmath": "*",
        "fgrosse/phpasn1": "~1.0.0",
        "symfony/console": "~2.6"
    },


### PR DESCRIPTION
This adds the dependency to the bcmath extension to the composer.json so composer install can notify users about missing mandatory dependencies.

If you don't have the extension installed locally the output from `composer install` will look as following:

```
$ composer install
Loading composer repositories with package information
Installing dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested PHP extension ext-bcmath * is missing from your system.
```

The extension requirement comes from the class `BcMathUtils`