### PR TITLE
Add check to the test bootstrapping for the maximum function level nesting

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,8 +17,10 @@ if (getenv('MATH_LIB') === false) {
 include buildPath(__DIR__, '..', 'vendor', 'autoload.php');
 
 $requiredNestingLevel = 150;
+
 if (extension_loaded('xdebug')) {
     $currentNestingLevel = intval(ini_get('xdebug.max_nesting_level'));
+
     if ($currentNestingLevel < $requiredNestingLevel) {
         fwrite(STDERR, <<<TEXT
 
@@ -39,3 +41,4 @@ TEXT
         ini_set('xdebug.max_nesting_level', $requiredNestingLevel);
     }
 }
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,3 +15,27 @@ if (getenv('MATH_LIB') === false) {
 }
 
 include buildPath(__DIR__, '..', 'vendor', 'autoload.php');
+
+$requiredNestingLevel = 150;
+if (extension_loaded('xdebug')) {
+    $currentNestingLevel = intval(ini_get('xdebug.max_nesting_level'));
+    if ($currentNestingLevel < $requiredNestingLevel) {
+        fwrite(STDERR, <<<TEXT
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+IMPORTANT NOTICE:
+It seems like you have the xdebug extension loaded.
+To use phpecc you have to increase the maximum nesting level from $currentNestingLevel to at least $requiredNestingLevel
+You can do this by adding the following line to your php.ini:
+
+xdebug.max_nesting_level = $requiredNestingLevel
+
+The tests will now run with this setting.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+TEXT
+        );
+        ini_set('xdebug.max_nesting_level', $requiredNestingLevel);
+    }
+}


### PR DESCRIPTION
I was just trying to run the whole test suit and ran into this issue.
When you have the xdebug extension loaded it will have a default maximum function level nesting of 100.
This is exceeded in the `NumberTheoryTests` so the tests for that fail.

It can be fixed easily by setting the php ini setting `xdebug.max_nesting_level = 150` (I just guessed 150 would be enough and it worked)

However it thought it might be a good idea to catch this issue before the tests run and notify the user about his bad configuration but still run the actual tests. This PR introduces this change