### PR TITLE
Refactor add/double operations

### DIFF
--- a/src/Console/Commands/DumpAsnCommand.php
+++ b/src/Console/Commands/DumpAsnCommand.php
@@ -30,7 +30,7 @@ class DumpAsnCommand extends AbstractCommand
         $this->printObject($output, $asnObject);
     }
 
-    private function printObject(OutputInterface $output, Object $object, $depth=0)
+    private function printObject(OutputInterface $output, Object $object, $depth = 0)
     {
         $treeSymbol = '';
         $depthString = str_repeat('─', $depth);

--- a/src/CurveFp.php
+++ b/src/CurveFp.php
@@ -23,6 +23,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 *************************************************************************/
 namespace Mdanter\Ecc;
 
+use Mdanter\Ecc\Math\PrimeFieldArithmetic;
+
 /**
  * This class is a representation of an EC over a field modulo a prime number
  *
@@ -58,6 +60,12 @@ class CurveFp implements CurveFpInterface
     protected $adapter = null;
 
     /**
+     *
+     * @var PrimeFieldArithmetic
+     */
+    protected $modAdapter = null;
+
+    /**
      * Constructor that sets up the instance variables.
      *
      * @param $prime int|string
@@ -70,8 +78,22 @@ class CurveFp implements CurveFpInterface
         $this->b = $b;
         $this->prime = $prime;
         $this->adapter = $adapter;
+        $this->modAdapter = new PrimeFieldArithmetic($this->adapter, $prime);
     }
 
+    /**
+     * (non-PHPdoc)
+     * @see \Mdanter\Ecc\CurveFpInterface::getModAdapter()
+     */
+    public function getModAdapter()
+    {
+        return $this->modAdapter;
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see \Mdanter\Ecc\CurveFpInterface::getInfinity()
+     */
     public function getInfinity()
     {
         return new Point($this->adapter, $this, 0, 0, 0, true);

--- a/src/CurveFpInterface.php
+++ b/src/CurveFpInterface.php
@@ -2,6 +2,8 @@
 
 namespace Mdanter\Ecc;
 
+use Mdanter\Ecc\Math\PrimeFieldArithmetic;
+
 /**
  * *********************************************************************
  * Copyright (C) 2012 Matyas Danter
@@ -32,6 +34,14 @@ namespace Mdanter\Ecc;
  */
 interface CurveFpInterface
 {
+
+    /**
+     * Returns a modular arithmetic adapter.
+     *
+     * @return PrimeFieldArithmetic
+     */
+    public function getModAdapter();
+
     /**
      * Returns the point identified by given coordinates.
      *
@@ -42,6 +52,11 @@ interface CurveFpInterface
      */
     public function getPoint($x, $y, $order = null);
 
+    /**
+     * Returns a point representing infinity on the curve.
+     *
+     * @return PointInterface
+     */
     public function getInfinity();
 
     /**

--- a/src/Math/PrimeFieldArithmetic.php
+++ b/src/Math/PrimeFieldArithmetic.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Mdanter\Ecc\Math;
+
+use Mdanter\Ecc\MathAdapterInterface;
+
+class PrimeFieldArithmetic
+{
+    private $adapter;
+
+    private $prime;
+
+    public function __construct(MathAdapterInterface $adapter, $prime)
+    {
+        $this->adapter = $adapter;
+        $this->prime = $prime;
+    }
+
+    public function add($augend, $addend)
+    {
+        return $this->adapter->mod($this->adapter->add($augend, $addend), $this->prime);
+    }
+
+    public function sub($minuend, $subtrahend)
+    {
+        return $this->adapter->mod($this->adapter->sub($minuend, $subtrahend), $this->prime);
+    }
+
+    public function mul($multiplier, $muliplicand)
+    {
+        return $this->adapter->mod($this->adapter->mul($multiplier, $muliplicand), $this->prime);
+    }
+
+    public function div($dividend, $divisor)
+    {
+        return $this->adapter->mod($this->adapter->mul($dividend, $this->adapter->inverseMod($divisor, $this->prime)), $this->prime);
+    }
+
+    public function pow($base, $exponent)
+    {
+        return $this->adapter->powmod($base, $exponent, $this->prime);
+    }
+}

--- a/src/Point.php
+++ b/src/Point.php
@@ -139,7 +139,7 @@ class Point implements PointInterface
 
         $math = $this->adapter;
 
-        if ($math->mod($math->cmp($this->x, $addend->getX()), $this->curve->getPrime()) == 0) {
+        if ($math->cmp($this->x, $addend->getX()) == 0) {
             if ($math->mod($math->add($this->y, $addend->getY()), $this->curve->getPrime()) == 0) {
                 return new self($this->adapter, $this->curve, 0, 0, 0, true);
             } else {

--- a/src/PointInterface.php
+++ b/src/PointInterface.php
@@ -58,8 +58,7 @@ interface PointInterface
      * Compares the current instance to another point.
      *
      * @param  PointInterface|Infinity $other
-     * @return int|string              A number less than 0 when current instance is less than the given point, 0 when they are equal,
-     *                                       and greater than 0 when current instance is greater than the given point.
+     * @return int|string              A number different than 0 when current instance is less than the given point, 0 when they are equal.
      */
     public function cmp(PointInterface $other);
 


### PR DESCRIPTION
Original implementation checks that `(cmp(addend->x, augend->x) % curve prime) == 0`.

Considering that cmp returns `0` on equality, a (non specified) negative value if `a < b`, and a (non specified) positive value if `a > b`, `(cmp(addend->x, augend->x) % curve prime) == 0` is true in only three cases:

- `cmp(addend->x, augend->x) == 0`
- `cmp(addend->x, augend->x) == 0 - curve prime` (or any multiple of curve prime)
- `cmp(addend->x, augend->x) == curve prime` (or any multiple of curve prime)

Hence, it's safer to only check that `cmp(addend->x, augend->x) == 0`. I haven't checked the implementation of `gmp_cmp`, but it might as well return randomly a value equal to curve prime (or one of its multiples), leading the point addition code to believe `addend->x == augend->x` are equal, when in fact, they're not.

As an added bonus, it removes one math OP, making the code a very tiny little (really tiny) bit faster.