### PR TITLE
Fix access to property on interface hinted variable

### DIFF
--- a/src/Point.php
+++ b/src/Point.php
@@ -160,7 +160,7 @@ class Point implements PointInterface
 
         $xR = $modMath->sub(
             $math->sub($math->pow($slope, 2), $this->x),
-            $addend->x
+            $addend->getX()
         );
 
         $yR = $modMath->sub(


### PR DESCRIPTION
Bugfix for a minor regression introduced in last P/R:

Direct property access on $addend->x assumes that $addend is an instance of Point, while that may not be always the case (ie. other libraries using this library and providing their own PointInterface implementations).

Ref https://scrutinizer-ci.com/g/mdanter/phpecc/inspections/10d73e9a-118c-4866-9894-95dc0e63ea7a/issues/files/src/Point.php?status=new&orderField=path&order=asc